### PR TITLE
[이동훈] 12주차 42578번 과제 제출합니다.

### DIFF
--- a/12주차/(P)42578/42578(P)_python_donghoon.py
+++ b/12주차/(P)42578/42578(P)_python_donghoon.py
@@ -1,0 +1,4 @@
+from collections import Counter
+from math import prod
+def solution(clothes):
+    return prod([x+1 for x in Counter([k for c, k in clothes]).values()]) - 1


### PR DESCRIPTION
Counter는 배열 내에서 해당 원소의 개수를 세어 줍니다.
math.prod는 배열 원소들끼리의 곱을 반환합니다.
모두 입지 않는 경우는 없으므로, `모든 경우의 수 - 1`이 정답이 됩니다.
각각의 카테고리에 대해서 입지 않는 경우까지 해서 `x+1`을 곱한 뒤 1을 뺐습니다!

```python
from collections import Counter
from math import prod
def solution(clothes):
    return prod([x+1 for x in Counter([k for c, k in clothes]).values()]) - 1 
```